### PR TITLE
Update preliminary-rh.rst

### DIFF
--- a/source/_includes/_installation/preliminary-rh.rst
+++ b/source/_includes/_installation/preliminary-rh.rst
@@ -30,7 +30,7 @@ RHEL 8
 
    * **EPEL**::
 
-       # dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+       # dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm 
 
 .. card:: SELinux 
 


### PR DESCRIPTION
   * **EPEL**::

       # dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm 

This information is not visible on the official documentation website
![2024-05-21 01 48 43](https://github.com/zextras/tech-doc/assets/84697434/39b957c3-bc38-441e-845e-3f48edfd8081)
.