### PR TITLE
Update rhel-pg-conf.rst

### DIFF
--- a/source/_includes/_installation/rhel-pg-conf.rst
+++ b/source/_includes/_installation/rhel-pg-conf.rst
@@ -3,7 +3,7 @@ To configure PostgreSQL, edit file
 :file:`/var/lib/pgsql/16/data/pg_hba.conf`, find the line::
 
   #IPv4 local connections:
-  host    all             all             127.0.0.1/32            ident
+  host    all             all             127.0.0.1/32            scram-sha-256
 
 
 remove the ``#`` before ``host`` (if present) and change it as follows::


### PR DESCRIPTION
Original configuration:
 #IPv4 local connections:
  host    all             all             127.0.0.1/32            ident

Modified Configuration:
 #IPv4 local connections:
  host    all             all             127.0.0.1/32            scram-sha-256

I noticed that in Postgresql 16 the default method is scram-sha-256 not ident. Therefore, we should fix the doc with the correct method.