### PR TITLE
Bug/authentication method in postgresql 16 ubuntu 22

### DIFF
--- a/source/_includes/_installation/rhel-pg-conf.rst
+++ b/source/_includes/_installation/rhel-pg-conf.rst
@@ -3,7 +3,7 @@ To configure PostgreSQL, edit file
 :file:`/var/lib/pgsql/16/data/pg_hba.conf`, find the line::
 
   #IPv4 local connections:
-  host    all             all             127.0.0.1/32            ident
+  host    all             all             127.0.0.1/32            scram-sha-256
 
 
 remove the ``#`` before ``host`` (if present) and change it as follows::

--- a/source/_includes/_installation/ubuntu-pg-conf.rst
+++ b/source/_includes/_installation/ubuntu-pg-conf.rst
@@ -3,7 +3,7 @@ To configure PostgreSQL, edit file
 :file:`/etc/postgresql/16/main/pg_hba.conf`, find the line::
 
   #IPv4 local connections:
-  host    all             all             127.0.0.1/32            ident
+  host    all             all             127.0.0.1/32            scram-sha-256
 
 
 remove the ``#`` before ``host`` (if present) and change it as follows::


### PR DESCRIPTION
Original config:
# IPv4 local connections:
host    all             all             127.0.0.1/32            ident

Modified Config:
# IPv4 local connections:
host    all             all             127.0.0.1/32            scram-sha-256

IN postgresql-16, scram-sha-256 is used as default method. So to avoid confusion we should fix this.
