### PR TITLE
Enh/adding postgresql repo in ubuntu 22 to install postgresql 16

### DIFF
--- a/source/carbonio-ce/install/scenarios/single-server-scenario.rst
+++ b/source/carbonio-ce/install/scenarios/single-server-scenario.rst
@@ -85,7 +85,7 @@ configure the PostgreSQL database.
 
       First, install PostgreSQL:
       
-      .. code:: console
+      .. code:: console::
          # sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
          # wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
          # apt update

--- a/source/carbonio-ce/install/scenarios/single-server-scenario.rst
+++ b/source/carbonio-ce/install/scenarios/single-server-scenario.rst
@@ -84,15 +84,16 @@ configure the PostgreSQL database.
       :sync: ubuntu
 
       First, install PostgreSQL:
+
+Note: Postgresql-16 is the latest LTS version of postgresql. Ubuntu 20.04LTS or Ubuntu 22.04LTS does not ship postgresql-16 as the default version. Therefore, to install 
+postgresql-16 we need to add postgres repository in to the system. Before sharing the postgresql repository adding steps, for your information, Ubuntu 22 ships postgresql-14 by default.
       
-      .. code:: console::
+      .. code:: console
+
          # sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
          # wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
          # apt update
          # apt install postgresql-16
-
-Note: Postgresql-16 is the latest LTS version of postgresql. Ubuntu 20.04LTS or Ubuntu 22.04LTS does not ship postgresql-16 as the default version. Therefore, to install 
-postgresql-16 we need to add postgres repository in to the system. Before sharing the postgresql repository adding steps, for your information, Ubuntu 22 ships postgresql-14 by default.
 
       .. include:: /_includes/_installation/ubuntu-pg-conf.rst
 

--- a/source/carbonio-ce/install/scenarios/single-server-scenario.rst
+++ b/source/carbonio-ce/install/scenarios/single-server-scenario.rst
@@ -86,15 +86,13 @@ configure the PostgreSQL database.
       First, install PostgreSQL:
       
       .. code:: console
-
-
-Note: Postgresql-16 is the latest LTS version of postgresql. Ubuntu 20.04LTS or Ubuntu 22.04LTS does not ship postgresql-16 as the default version. Therefore, to install 
-postgresql-16 we need to add postgres repository in to the system. Before sharing the postgresql repository adding steps, for your information, Ubuntu 22 ships postgresql-14 by default.
-
          # sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
          # wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
          # apt update
          # apt install postgresql-16
+
+Note: Postgresql-16 is the latest LTS version of postgresql. Ubuntu 20.04LTS or Ubuntu 22.04LTS does not ship postgresql-16 as the default version. Therefore, to install 
+postgresql-16 we need to add postgres repository in to the system. Before sharing the postgresql repository adding steps, for your information, Ubuntu 22 ships postgresql-14 by default.
 
       .. include:: /_includes/_installation/ubuntu-pg-conf.rst
 

--- a/source/carbonio-ce/install/scenarios/single-server-scenario.rst
+++ b/source/carbonio-ce/install/scenarios/single-server-scenario.rst
@@ -87,6 +87,13 @@ configure the PostgreSQL database.
       
       .. code:: console
 
+
+Note: Postgresql-16 is the latest LTS version of postgresql. Ubuntu 20.04LTS or Ubuntu 22.04LTS does not ship postgresql-16 as the default version. Therefore, to install 
+postgresql-16 we need to add postgres repository in to the system. Before sharing the postgresql repository adding steps, for your information, Ubuntu 22 ships postgresql-14 by default.
+
+         # sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+         # wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+         # apt update
          # apt install postgresql-16
 
       .. include:: /_includes/_installation/ubuntu-pg-conf.rst


### PR DESCRIPTION
First, install PostgreSQL:

Note: Postgresql-16 is the latest LTS version of postgresql. Ubuntu 20.04LTS or Ubuntu 22.04LTS does not ship postgresql-16 as the default version. Therefore, to install 
postgresql-16 we need to add postgres repository in to the system. Before sharing the postgresql repository adding steps, for your information, Ubuntu 22 ships postgresql-14 by default.
      
      .. code:: console

         # sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
         # wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
         # apt update
         # apt install postgresql-16
