### PR TITLE
Modification in the script of install carbonio ce singleserver (ubuntu & rhel)

### DIFF
--- a/source/carbonio-ce/scripts/install_carbonio_ce_singleserver_rhel.sh
+++ b/source/carbonio-ce/scripts/install_carbonio_ce_singleserver_rhel.sh
@@ -69,7 +69,7 @@ PGPASSWORD=$POSTGRES_SECRET carbonio-message-dispatcher-db-bootstrap carbonio_ad
 
 PACKAGES="carbonio-message-dispatcher"
 dnf install -y $PACKAGES
-PGPASSWORD=$POSTGRES_SECRET carbonio-message-dispatcher-migration carbonio_adm 127.0.0.1
+PGPASSWORD=$POSTGRES_SECRET carbonio-message-dispatcher-migration carbonio_adm 127.0.0.1 20000
 
 dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
 

--- a/source/carbonio-ce/scripts/install_carbonio_ce_singleserver_ubuntu.sh
+++ b/source/carbonio-ce/scripts/install_carbonio_ce_singleserver_ubuntu.sh
@@ -62,7 +62,7 @@ PGPASSWORD=$POSTGRES_SECRET carbonio-message-dispatcher-db-bootstrap carbonio_ad
 
 PACKAGES="carbonio-message-dispatcher"
 apt install -y $PACKAGES
-PGPASSWORD=$POSTGRES_SECRET carbonio-message-dispatcher-migration carbonio_adm 127.0.0.1
+PGPASSWORD=$POSTGRES_SECRET carbonio-message-dispatcher-migration carbonio_adm 127.0.0.1 20000
 
 PACKAGES="carbonio-videoserver-ce"
 apt install -y $PACKAGES


### PR DESCRIPTION
For Ubuntu
#########################################################
[Link]
tech-doc/source/carbonio-ce/scripts/install_carbonio_ce_singleserver_ubuntu.sh

[Current Instruction]
PGPASSWORD=$POSTGRES_SECRET carbonio-message-dispatcher-migration carbonio_adm 127.0.0.1

[Modified Instruction] - Line: 65
PGPASSWORD=$POSTGRES_SECRET carbonio-message-dispatcher-migration carbonio_adm 127.0.0.1 20000

For RHEL
#########################################################
[Link]
tech-doc/source/carbonio-ce/scripts/install_carbonio_ce_singleserver_rhel.sh

[Current Instruction]
PGPASSWORD=$POSTGRES_SECRET carbonio-message-dispatcher-migration carbonio_adm 127.0.0.1

[Modified Instruction] - Line: 72
PGPASSWORD=$POSTGRES_SECRET carbonio-message-dispatcher-migration carbonio_adm 127.0.0.1 20000