### PR TITLE
Zmcertmgr should run as zextras (no longer runs as root)

### DIFF
--- a/source/_includes/_postinstallation/SSL-certificate.rst
+++ b/source/_includes/_postinstallation/SSL-certificate.rst
@@ -64,7 +64,7 @@ values according to your organisation.
 
       .. code:: console
 
-         # /opt/zextras/bin/zmcertmgr createcsr comm -new -subject \
+         $ /opt/zextras/bin/zmcertmgr createcsr comm -new -subject \
          "/C=IT/ST=VR/L=Yourtown/O=YourCompany/OU=SampleDepartment/CN=mail.example.com" \
          -subjectAltNames mail.example.com
 
@@ -77,7 +77,7 @@ values according to your organisation.
 
       .. code:: console
 
-         # /opt/zextras/bin/zmcertmgr createcsr comm -new -subject \
+         $ /opt/zextras/bin/zmcertmgr createcsr comm -new -subject \
          "/C=IT/ST=VR/L=Yourtown/O=YourCompany/OU=SampleDepartment/CN=*.example.com"
 
    .. grid-item-card::

--- a/source/_includes/verifycerts.rst
+++ b/source/_includes/verifycerts.rst
@@ -25,17 +25,17 @@ If the verification is successful, you can deploy the SSL certificate.
 
 .. code:: console
 
-   # zmcertmgr deploycrt comm commercial.crt commercial_ca.crt
+   $ zmcertmgr deploycrt comm commercial.crt commercial_ca.crt
 
 Finally, restart |product|.
 
 .. code:: console
 
-   # zmcontrol restart
+   $ zmcontrol restart
 
 Your certificate should now be installed: verify the certificate
 details by running this command:
 
 .. code:: console
 
-   # zmcertmgr viewdeployedcrt
+   $ zmcertmgr viewdeployedcrt


### PR DESCRIPTION
It is about displaying appropriate shell while executing commands in [https://docs.zextras.com/carbonio-ce/html/postinstall/sslcert.html#commercial-certificate-installation].

############# One sample is: #############
root@mail:~# /opt/zextras/bin/zmcertmgr createcsr comm -new -subject \
"/C=BD/ST=Dhaka/L=Dhaka/O=BOL/OU=Marketing/CN=mail.zextras.xyz" \
-subjectAltNames mail.zextras.xyz
zmcertmgr: ERROR: no longer runs as root!
