### PR TITLE
feat: added carbonio-catalog-service in the mesh-role mandatory services list

### DIFF
--- a/source/_includes/_installation/_roles/role-mesh-ds.rst
+++ b/source/_includes/_installation/_roles/role-mesh-ds.rst
@@ -6,14 +6,14 @@
 
       .. code:: console
 
-         # apt install service-discover-server carbonio-directory-server
+         # apt install service-discover-server carbonio-directory-server carbonio-catalog-service
  
    .. tab-item:: RHEL
       :sync: rhel
 
       .. code:: console
 
-         # dnf install service-discover-server carbonio-directory-server
+         # dnf install service-discover-server carbonio-directory-server carbonio-catalog-service
 
 .. note:: Unlike other client-server software (like e.g., PostgreSQL),
    the ``service-discover`` software on which |product| is based does

--- a/source/_includes/_installation/step-package-install.rst
+++ b/source/_includes/_installation/step-package-install.rst
@@ -47,7 +47,7 @@ Next, we install all packages needed for |product|.
       .. code:: console
 
          # apt install service-discover-server \
-         carbonio-directory-server carbonio-proxy carbonio-webui \
+         carbonio-directory-server carbonio-catalog-service carbonio-proxy carbonio-webui \
          carbonio-files-ui carbonio-mta carbonio-mailbox-db \
          carbonio-appserver carbonio-user-management \
          carbonio-files-ce carbonio-files-public-folder-ui \
@@ -66,7 +66,7 @@ Next, we install all packages needed for |product|.
       .. code:: console
 
          # apt install service-discover-server \
-         carbonio-directory-server carbonio-proxy carbonio-webui \
+         carbonio-directory-server carbonio-catalog-service carbonio-proxy carbonio-webui \
          carbonio-files-ui carbonio-mta carbonio-mailbox-db \
          carbonio-appserver carbonio-user-management \
          carbonio-files-ce carbonio-files-public-folder-ui \
@@ -93,7 +93,7 @@ Next, we install all packages needed for |product|.
 
       .. code:: console
 
-         # dnf install carbonio-directory-server carbonio-proxy \
+         # dnf install carbonio-directory-server carbonio-catalog-service carbonio-proxy \
          carbonio-webui carbonio-files-ui carbonio-mta \
          carbonio-mailbox-db carbonio-appserver \
          carbonio-user-management carbonio-preview-ce \
@@ -121,7 +121,7 @@ Next, we install all packages needed for |product|.
 
       .. code:: console
 
-         # dnf install carbonio-directory-server carbonio-proxy \
+         # dnf install carbonio-directory-server carbonio-catalog-service carbonio-proxy \
          carbonio-webui carbonio-files-ui carbonio-mta \
          carbonio-mailbox-db carbonio-appserver \
          carbonio-user-management carbonio-preview-ce \

--- a/source/carbonio-ce/install/roles.rst
+++ b/source/carbonio-ce/install/roles.rst
@@ -61,6 +61,7 @@ This is the list of roles that make up a |product| installation.
 
       * service-discover-server
       * carbonio-directory-server
+      * carbonio-catalog-service
 
    .. grid-item-card:: Database
       :columns: 6

--- a/source/carbonio-ce/scripts/install_carbonio_ce_singleserver_rhel.sh
+++ b/source/carbonio-ce/scripts/install_carbonio_ce_singleserver_rhel.sh
@@ -32,7 +32,7 @@ dnf -y install postgresql16 postgresql16-server;
 /usr/pgsql-16/bin/postgresql-16-setup initdb;
 systemctl enable --now postgresql-16;
 
-PACKAGES="service-discover-server carbonio-directory-server carbonio-proxy carbonio-webui carbonio-files-ui carbonio-mta carbonio-mailbox-db carbonio-appserver carbonio-user-management carbonio-files-ce carbonio-files-public-folder-ui carbonio-files-db carbonio-tasks-ce carbonio-tasks-db carbonio-tasks-ui carbonio-storages-ce carbonio-preview-ce carbonio-docs-connector-ce carbonio-docs-connector-db carbonio-docs-editor carbonio-prometheus carbonio-message-broker  carbonio-ws-collaboration-ce carbonio-ws-collaboration-db carbonio-ws-collaboration-ui"
+PACKAGES="service-discover-server carbonio-directory-server carbonio-catalog-service carbonio-proxy carbonio-webui carbonio-files-ui carbonio-mta carbonio-mailbox-db carbonio-appserver carbonio-user-management carbonio-files-ce carbonio-files-public-folder-ui carbonio-files-db carbonio-tasks-ce carbonio-tasks-db carbonio-tasks-ui carbonio-storages-ce carbonio-preview-ce carbonio-docs-connector-ce carbonio-docs-connector-db carbonio-docs-editor carbonio-prometheus carbonio-message-broker  carbonio-ws-collaboration-ce carbonio-ws-collaboration-db carbonio-ws-collaboration-ui"
 
 echo '' > config.conf
 dnf install -y $PACKAGES 

--- a/source/carbonio-ce/scripts/install_carbonio_ce_singleserver_ubuntu.sh
+++ b/source/carbonio-ce/scripts/install_carbonio_ce_singleserver_ubuntu.sh
@@ -27,7 +27,7 @@ wget -O- "https://www.postgresql.org/media/keys/ACCC4CF8.asc" | gpg --dearmor | 
 chmod 644 /usr/share/keyrings/postgres.gpg
 sed -i 's/deb/deb [signed-by=\/usr\/share\/keyrings\/postgres.gpg] /' /etc/apt/sources.list.d/pgdg.list
 
-PACKAGES="postgresql-16 service-discover-server carbonio-directory-server carbonio-proxy carbonio-webui carbonio-files-ui carbonio-mta carbonio-mailbox-db carbonio-appserver carbonio-user-management carbonio-files-ce carbonio-files-public-folder-ui carbonio-files-db carbonio-tasks-ce carbonio-tasks-db carbonio-tasks-ui carbonio-storages-ce carbonio-preview-ce carbonio-docs-connector-ce carbonio-docs-connector-db carbonio-docs-editor carbonio-prometheus carbonio-message-broker  carbonio-ws-collaboration-ce carbonio-ws-collaboration-db carbonio-ws-collaboration-ui"
+PACKAGES="postgresql-16 service-discover-server carbonio-directory-server carbonio-catalog-service carbonio-proxy carbonio-webui carbonio-files-ui carbonio-mta carbonio-mailbox-db carbonio-appserver carbonio-user-management carbonio-files-ce carbonio-files-public-folder-ui carbonio-files-db carbonio-tasks-ce carbonio-tasks-db carbonio-tasks-ui carbonio-storages-ce carbonio-preview-ce carbonio-docs-connector-ce carbonio-docs-connector-db carbonio-docs-editor carbonio-prometheus carbonio-message-broker  carbonio-ws-collaboration-ce carbonio-ws-collaboration-db carbonio-ws-collaboration-ui"
 
 echo '' > config.conf
 apt update -y -q


### PR DESCRIPTION
In 24.12.0 we will add a new mandatory service, carbonio-catalog-service, to implement  https://zextras.atlassian.net/browse/CO-1372 and https://zextras.atlassian.net/browse/CO-1373

This PR adds basic documentation for it.