### PR TITLE
ZTD-1712-remove-carbonio-mailbox-db-from-ce-doc

### DIFF
--- a/source/_includes/_architecture/_components/component-db-connector-ce.rst
+++ b/source/_includes/_architecture/_components/component-db-connector-ce.rst
@@ -5,8 +5,7 @@
 
       .. code:: console
 
-         # apt install carbonio-files-db carbonio-mailbox-db \
-           carbonio-tasks-db \
+         # apt install carbonio-files-db carbonio-tasks-db \
            carbonio-message-dispatcher-db \
            carbonio-ws-collaboration-db
  
@@ -15,7 +14,6 @@
 
       .. code:: console
 
-         # dnf install carbonio-files-db carbonio-mailbox-db \
-           carbonio-tasks-db \
+         # dnf install carbonio-files-db carbonio-tasks-db \
            carbonio-message-dispatcher-db \
            carbonio-ws-collaboration-db

--- a/source/_includes/_installation/_steps/db-bootstrap-ce.rst
+++ b/source/_includes/_installation/_steps/db-bootstrap-ce.rst
@@ -1,10 +1,3 @@
-.. card:: Mailbox
-
-  .. code:: console
-
-     # PGPASSWORD=$DB_ADM_PWD carbonio-mailbox-db-bootstrap carbonio_adm 127.0.0.1
-
-
 .. card:: |file|
 
   .. code:: console

--- a/source/carbonio-ce/architecture/components.rst
+++ b/source/carbonio-ce/architecture/components.rst
@@ -52,7 +52,6 @@ This is the list of Components that make up a |product| installation.
 
       * postgresql
       * carbonio-files-db
-      * carbonio-mailbox-db
       * carbonio-tasks-db
       * carbonio-message-dispatcher-db
       * carbonio-ws-collaboration-db

--- a/source/carbonio-ce/scripts/install_carbonio_ce_singleserver_rhel.sh
+++ b/source/carbonio-ce/scripts/install_carbonio_ce_singleserver_rhel.sh
@@ -32,7 +32,7 @@ dnf -y install postgresql16 postgresql16-server;
 /usr/pgsql-16/bin/postgresql-16-setup initdb;
 systemctl enable --now postgresql-16;
 
-PACKAGES="service-discover-server carbonio-directory-server carbonio-proxy carbonio-webui carbonio-files-ui carbonio-mta carbonio-mailbox-db carbonio-appserver carbonio-user-management carbonio-files-ce carbonio-files-public-folder-ui carbonio-files-db carbonio-tasks-ce carbonio-tasks-db carbonio-tasks-ui carbonio-storages-ce carbonio-preview-ce carbonio-docs-connector-ce carbonio-docs-editor carbonio-prometheus carbonio-message-broker  carbonio-ws-collaboration-ce carbonio-ws-collaboration-db carbonio-ws-collaboration-ui carbonio-catalog"
+PACKAGES="service-discover-server carbonio-directory-server carbonio-proxy carbonio-webui carbonio-files-ui carbonio-mta carbonio-appserver carbonio-user-management carbonio-files-ce carbonio-files-public-folder-ui carbonio-files-db carbonio-tasks-ce carbonio-tasks-db carbonio-tasks-ui carbonio-storages-ce carbonio-preview-ce carbonio-docs-connector-ce carbonio-docs-editor carbonio-prometheus carbonio-message-broker  carbonio-ws-collaboration-ce carbonio-ws-collaboration-db carbonio-ws-collaboration-ui carbonio-catalog"
 
 echo '' > config.conf
 dnf install -y $PACKAGES 
@@ -56,7 +56,6 @@ sed -i 's/ident/md5/g' /var/lib/pgsql/16/data/pg_hba.conf
 systemctl reload postgresql-16
 
 PGPASSWORD=$POSTGRES_SECRET carbonio-files-db-bootstrap carbonio_adm 127.0.0.1
-PGPASSWORD=$POSTGRES_SECRET carbonio-mailbox-db-bootstrap carbonio_adm 127.0.0.1
 PGPASSWORD=$POSTGRES_SECRET carbonio-tasks-db-bootstrap carbonio_adm 127.0.0.1
 PGPASSWORD=$POSTGRES_SECRET carbonio-ws-collaboration-db-bootstrap carbonio_adm 127.0.0.1
 

--- a/source/carbonio-ce/scripts/install_carbonio_ce_singleserver_ubuntu.sh
+++ b/source/carbonio-ce/scripts/install_carbonio_ce_singleserver_ubuntu.sh
@@ -27,7 +27,7 @@ wget -O- "https://www.postgresql.org/media/keys/ACCC4CF8.asc" | gpg --dearmor | 
 chmod 644 /usr/share/keyrings/postgres.gpg
 sed -i 's/deb/deb [signed-by=\/usr\/share\/keyrings\/postgres.gpg] /' /etc/apt/sources.list.d/pgdg.list
 
-PACKAGES="postgresql-16 service-discover-server carbonio-directory-server carbonio-proxy carbonio-webui carbonio-files-ui carbonio-mta carbonio-mailbox-db carbonio-appserver carbonio-user-management carbonio-files-ce carbonio-files-public-folder-ui carbonio-files-db carbonio-tasks-ce carbonio-tasks-db carbonio-tasks-ui carbonio-storages-ce carbonio-preview-ce carbonio-docs-connector-ce carbonio-docs-editor carbonio-prometheus carbonio-message-broker  carbonio-ws-collaboration-ce carbonio-ws-collaboration-db carbonio-ws-collaboration-ui carbonio-catalog"
+PACKAGES="postgresql-16 service-discover-server carbonio-directory-server carbonio-proxy carbonio-webui carbonio-files-ui carbonio-mta carbonio-appserver carbonio-user-management carbonio-files-ce carbonio-files-public-folder-ui carbonio-files-db carbonio-tasks-ce carbonio-tasks-db carbonio-tasks-ui carbonio-storages-ce carbonio-preview-ce carbonio-docs-connector-ce carbonio-docs-editor carbonio-prometheus carbonio-message-broker  carbonio-ws-collaboration-ce carbonio-ws-collaboration-db carbonio-ws-collaboration-ui carbonio-catalog"
 
 echo '' > config.conf
 apt update -y -q
@@ -50,7 +50,6 @@ su - postgres -c "psql --command=\"CREATE ROLE carbonio_adm WITH LOGIN SUPERUSER
 su - postgres -c "psql --command=\"CREATE DATABASE carbonio_adm OWNER carbonio_adm;\""
 
 PGPASSWORD=$POSTGRES_SECRET carbonio-files-db-bootstrap carbonio_adm 127.0.0.1
-PGPASSWORD=$POSTGRES_SECRET carbonio-mailbox-db-bootstrap carbonio_adm 127.0.0.1
 PGPASSWORD=$POSTGRES_SECRET carbonio-tasks-db-bootstrap carbonio_adm 127.0.0.1
 PGPASSWORD=$POSTGRES_SECRET carbonio-ws-collaboration-db-bootstrap carbonio_adm 127.0.0.1
 


### PR DESCRIPTION
Removed carbonio-mailbox-db and the related commands from Carbonio CE documentation, module is still valid for Carbonio Advanced