### PR TITLE
ZTD-1745-add-bosnian-to-the-community-supported-languages-list

### DIFF
--- a/source/_includes/_general/languages.rst
+++ b/source/_includes/_general/languages.rst
@@ -26,6 +26,7 @@ languages
       .. csv-table::
          :header: "Language", "code"
 
+         "Bosnian","bs"
          "Dutch","nl"
          "German","de"
          "Hungarian", "hu"


### PR DESCRIPTION
Bosnian (bs) was added to the list of Community Supported Languages in the documentation.