### PR TITLE
ZTD-1752-public-documentation-for-ub-24-rh-9-should-use-carbonio-targ…

### DIFF
--- a/source/carbonio/admincli/advancedadmin.rst
+++ b/source/carbonio/admincli/advancedadmin.rst
@@ -302,10 +302,8 @@ Restart |product| services to apply the changes.
 
       .. code:: console
 
-         # systemctl restart carbonio-directory-server.target
-         # systemctl restart carbonio-appserver.target
-         # systemctl restart carbonio-mta.target
-         # systemctl restart carbonio-proxy.target
+         systemctl restart carbonio.target
+
 
    .. tab-item:: RHEL 8
       :sync: rhel8
@@ -323,7 +321,5 @@ Restart |product| services to apply the changes.
 
       .. code:: console
 
-         # systemctl restart carbonio-directory-server.target
-         # systemctl restart carbonio-appserver.target
-         # systemctl restart carbonio-mta.target
-         # systemctl restart carbonio-proxy.target
+         systemctl restart carbonio.target
+


### PR DESCRIPTION
ZTD-1752-public-documentation-for-ub-24-rh-9-should-use-carbonio-target-instead-restart-multiple-services

Changed targeted individual commands for the global target, ensuring no components are missing