### PR TITLE
ZTD-1755-remove-single-srv-install-and-cluster-services-redundancy-fr…

### DIFF
--- a/source/carbonio/upgrade/changelogs.rst
+++ b/source/carbonio/upgrade/changelogs.rst
@@ -49,22 +49,9 @@ that you can find here:
 
    Installation
 
-.. button-link:: https://github.com/zextras/carbonio-ansible-ssinstall/blob/main/CHANGELOG.md
-   :color: danger
-   :outline:
-
-   Single-Server Installation
-
 .. button-link::
    https://github.com/zextras/carbonio-upgrade-ansible/blob/main/CHANGELOG.md
    :color: danger
    :outline:
 
    Upgrade
-
-.. button-link::
-   https://github.com/zextras/sps-carbonio-ha-ansible-setup/blob/main/CHANGELOG.md
-   :color: danger
-   :outline:
-
-   Cluster Services Redundancy


### PR DESCRIPTION
Removed two buttons 'Single-Server Installation' and 'Cluster Services Redundancy' from changelogs page