### PR TITLE
fix(ci): use zextras-dev-docs credential for S3 staging access

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,7 +22,7 @@ pipeline {
     DEVEL_BRANCH = "devel"
     DEVEL_BUCKET_NAME = "zextrasdoc-devel"
     PRODUCTION_CREDENTIALS = "docs.zextras.com-s3-key"
-    STAGING_CREDENTIALS = "doc-zextras-area51-s3-key"
+    STAGING_CREDENTIALS = "zextras-dev-docs-s3-key"
     REGION = 'eu-west-1'
   }
 


### PR DESCRIPTION
## Summary

Replace the legacy `doc-zextras-area51-s3-key` Jenkins credential with `zextras-dev-docs-s3-key` for staging/devel S3 uploads.

## Root Cause

The old IAM user (`doc-zextras-area51-s3-only`) was hitting a 403 on `S3DeleteStep.doesObjectExist()` after a public bucket policy was applied to `zextrasdoc-devel`. Once a resource policy exists, AWS requires explicit IAM allowance — the legacy manual policy `docs.zextras.com-devel-s3-only` lacks `s3:GetObject`, which `HeadObject` requires.

## Change

- `STAGING_CREDENTIALS`: `doc-zextras-area51-s3-key` → `zextras-dev-docs-s3-key`

The new IAM user `zextras-dev-docs` has an explicit `read-write` policy on both `zextrasdoc` and `zextrasdoc-devel` buckets, so the single credential covers both the `devel` and `pre_release` upload stages.

## Dependencies

This PR depends on [infra-terraform-aws#73](https://github.com/zextras/infra-terraform-aws/pull/73) being merged and applied, and the `zextras-dev-docs-s3-key` Jenkins credential being created with the resulting access key before this is merged.

Refs: [IN-1115](https://zextras.atlassian.net/browse/IN-1115)

[IN-1115]: https://zextras.atlassian.net/browse/IN-1115?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ