### PR TITLE
ci: call properties(defaultPipelineProperties()) before pipeline {}

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,6 +7,8 @@ library(
     ])
 )
 
+properties(defaultPipelineProperties())
+
 pipeline {
   agent {
     node {


### PR DESCRIPTION
## Description

Follow-up to #1583 (jenkins-lib-common#189 consumer audit). `properties(defaultPipelineProperties())` was missed in the original migration PR — it's the call that enrolls the pipeline in the org-wide Throttle Concurrent Builds categories (see `jenkins-lib-common/docs/jcasc-throttle-categories.md`), which manage Jenkins server resource starvation from too many concurrent jobs.

## Changes

- `Jenkinsfile`: add `properties(defaultPipelineProperties())` before `pipeline {}`

## Notes for reviewers

`disableConcurrentBuilds()` alone only stops this job/branch from overlapping with itself — it does not throttle against other repos' builds sharing the same pod pool. `defaultPipelineProperties()` is the cross-job/cross-repo throttle.