### PR TITLE
docs(CO-4207): remove carbonio-webui from install docs

### DIFF
--- a/source/_includes/_architecture/_components/component-proxy-ce.rst
+++ b/source/_includes/_architecture/_components/component-proxy-ce.rst
@@ -5,7 +5,7 @@
 
       .. code:: console
 
-         # apt install carbonio-proxy carbonio-webui \
+         # apt install carbonio-proxy \
            carbonio-files-ui carbonio-tasks-ui \
            carbonio-ws-collaboration-ui  carbonio-catalog \
            carbonio-files-public-folder-ui carbonio-memcached
@@ -15,7 +15,7 @@
 
       .. code:: console
 
-         # dnf install carbonio-proxy carbonio-webui \
+         # dnf install carbonio-proxy \
            carbonio-files-ui carbonio-tasks-ui \
            carbonio-ws-collaboration-ui carbonio-catalog \
            carbonio-files-public-folder-ui carbonio-memcached

--- a/source/_includes/_architecture/_packages/component-proxy.rst
+++ b/source/_includes/_architecture/_packages/component-proxy.rst
@@ -6,7 +6,7 @@
       .. code:: console
 
          # apt install carbonio-proxy carbonio-catalog \
-          carbonio-files-public-folder-ui carbonio-webui \
+          carbonio-files-public-folder-ui \
           carbonio-tasks-ui carbonio-files-ui \
           carbonio-ws-collaboration-ui carbonio-avdb-updater
 
@@ -17,7 +17,7 @@
       .. code:: console
 
          # apt install carbonio-proxy carbonio-catalog \
-          carbonio-files-public-folder-ui carbonio-webui \
+          carbonio-files-public-folder-ui \
           carbonio-tasks-ui carbonio-files-ui \
           carbonio-ws-collaboration-ui carbonio-avdb-updater
 
@@ -28,7 +28,7 @@
       .. code:: console
 
          # dnf install carbonio-proxy carbonio-catalog \
-          carbonio-files-public-folder-ui carbonio-webui \
+          carbonio-files-public-folder-ui \
           carbonio-tasks-ui carbonio-files-ui \
           carbonio-ws-collaboration-ui carbonio-avdb-updater
 
@@ -38,6 +38,6 @@
       .. code:: console
 
          # dnf install carbonio-proxy carbonio-catalog \
-          carbonio-files-public-folder-ui carbonio-webui \
+          carbonio-files-public-folder-ui \
           carbonio-tasks-ui carbonio-files-ui \
           carbonio-ws-collaboration-ui carbonio-avdb-updater

--- a/source/_includes/_installation/step-package-install-single-cb.rst
+++ b/source/_includes/_installation/step-package-install-single-cb.rst
@@ -18,7 +18,7 @@ Next, we install the base packages needed for |product|.
          carbonio-directory-server carbonio-proxy carbonio-mta \
          carbonio-advanced carbonio-zal carbonio-user-management \
          carbonio-storages carbonio-message-broker carbonio-files \
-         carbonio-preview carbonio-catalog carbonio-webui \
+         carbonio-preview carbonio-catalog \
          carbonio-files-public-folder-ui carbonio-files-ui \
          carbonio-mailbox-db carbonio-files-db postgresql-16
 
@@ -31,7 +31,7 @@ Next, we install the base packages needed for |product|.
          carbonio-directory-server carbonio-proxy carbonio-mta \
          carbonio-advanced carbonio-zal carbonio-user-management \
          carbonio-storages carbonio-message-broker carbonio-files \
-         carbonio-preview carbonio-catalog carbonio-webui \
+         carbonio-preview carbonio-catalog \
          carbonio-files-public-folder-ui carbonio-files-ui \
          carbonio-mailbox-db carbonio-files-db postgresql-16
 
@@ -59,7 +59,7 @@ Next, we install the base packages needed for |product|.
          carbonio-directory-server carbonio-proxy carbonio-mta \
          carbonio-advanced carbonio-zal carbonio-user-management \
          carbonio-storages carbonio-message-broker carbonio-files \
-         carbonio-preview carbonio-catalog carbonio-webui \
+         carbonio-preview carbonio-catalog \
          carbonio-files-public-folder-ui carbonio-files-ui \
          carbonio-mailbox-db carbonio-files-db postgresql16-server
 
@@ -94,7 +94,7 @@ Next, we install the base packages needed for |product|.
          carbonio-directory-server carbonio-proxy carbonio-mta \
          carbonio-advanced carbonio-zal carbonio-user-management \
          carbonio-storages carbonio-message-broker carbonio-files \
-         carbonio-preview carbonio-catalog carbonio-webui \
+         carbonio-preview carbonio-catalog \
          carbonio-files-public-folder-ui carbonio-files-ui \
          carbonio-mailbox-db carbonio-files-db postgresql16-server
 

--- a/source/_includes/_installation/step-package-install.rst
+++ b/source/_includes/_installation/step-package-install.rst
@@ -15,7 +15,7 @@ Next, we install all packages needed for |product|.
       .. code:: console
 
          # apt install service-discover-server \
-         carbonio-directory-server carbonio-proxy carbonio-webui \
+         carbonio-directory-server carbonio-proxy \
          carbonio-files-ui carbonio-mta \
          carbonio-appserver carbonio-user-management \
          carbonio-files-ce carbonio-files-public-folder-ui \
@@ -34,7 +34,7 @@ Next, we install all packages needed for |product|.
       .. code:: console
 
          # apt install service-discover-server \
-         carbonio-directory-server carbonio-proxy carbonio-webui \
+         carbonio-directory-server carbonio-proxy \
          carbonio-files-ui carbonio-mta \
          carbonio-appserver carbonio-user-management \
          carbonio-files-ce carbonio-files-public-folder-ui \
@@ -62,7 +62,7 @@ Next, we install all packages needed for |product|.
       .. code:: console
 
          # dnf install carbonio-directory-server carbonio-proxy \
-         carbonio-webui carbonio-files-ui carbonio-mta \
+         carbonio-files-ui carbonio-mta \
          carbonio-appserver \
          carbonio-user-management carbonio-preview-ce \
          carbonio-files-ce carbonio-files-public-folder-ui \
@@ -91,7 +91,7 @@ Next, we install all packages needed for |product|.
       .. code:: console
 
          # dnf install carbonio-directory-server carbonio-proxy \
-         carbonio-webui carbonio-files-ui carbonio-mta \
+         carbonio-files-ui carbonio-mta \
          carbonio-appserver \
          carbonio-user-management carbonio-preview-ce \
          carbonio-files-ce carbonio-files-public-folder-ui \
@@ -104,4 +104,3 @@ Next, we install all packages needed for |product|.
          carbonio-ws-collaboration-db carbonio-ws-collaboration-ui \
          carbonio-ws-collaboration-ce carbonio-videoserver-ce \
          carbonio-catalog carbonio-memcached
-

--- a/source/carbonio-ce/scripts/install_carbonio_ce_singleserver_rhel.sh
+++ b/source/carbonio-ce/scripts/install_carbonio_ce_singleserver_rhel.sh
@@ -32,7 +32,7 @@ dnf -y install postgresql16 postgresql16-server;
 /usr/pgsql-16/bin/postgresql-16-setup initdb;
 systemctl enable --now postgresql-16;
 
-PACKAGES="service-discover-server carbonio-directory-server carbonio-proxy carbonio-webui carbonio-files-ui carbonio-mta carbonio-appserver carbonio-user-management carbonio-files-ce carbonio-files-public-folder-ui carbonio-files-db carbonio-tasks-ce carbonio-tasks-db carbonio-tasks-ui carbonio-storages-ce carbonio-preview-ce carbonio-docs-connector-ce carbonio-docs-editor carbonio-prometheus carbonio-message-broker  carbonio-ws-collaboration-ce carbonio-ws-collaboration-db carbonio-ws-collaboration-ui carbonio-catalog carbonio-memcached"
+PACKAGES="service-discover-server carbonio-directory-server carbonio-proxy carbonio-files-ui carbonio-mta carbonio-appserver carbonio-user-management carbonio-files-ce carbonio-files-public-folder-ui carbonio-files-db carbonio-tasks-ce carbonio-tasks-db carbonio-tasks-ui carbonio-storages-ce carbonio-preview-ce carbonio-docs-connector-ce carbonio-docs-editor carbonio-prometheus carbonio-message-broker  carbonio-ws-collaboration-ce carbonio-ws-collaboration-db carbonio-ws-collaboration-ui carbonio-catalog carbonio-memcached"
 
 echo '' > config.conf
 dnf install -y $PACKAGES 
@@ -94,4 +94,3 @@ echo "Please store it in a safe place, otherwise you will need to reset it!"
 else
     echo "###### Carbonio repo are not configured. ######"
 fi
-

--- a/source/carbonio-ce/scripts/install_carbonio_ce_singleserver_ubuntu.sh
+++ b/source/carbonio-ce/scripts/install_carbonio_ce_singleserver_ubuntu.sh
@@ -27,7 +27,7 @@ wget -O- "https://www.postgresql.org/media/keys/ACCC4CF8.asc" | gpg --dearmor | 
 chmod 644 /usr/share/keyrings/postgres.gpg
 sed -i 's/deb/deb [signed-by=\/usr\/share\/keyrings\/postgres.gpg] /' /etc/apt/sources.list.d/pgdg.list
 
-PACKAGES="postgresql-16 service-discover-server carbonio-directory-server carbonio-proxy carbonio-webui carbonio-files-ui carbonio-mta carbonio-appserver carbonio-user-management carbonio-files-ce carbonio-files-public-folder-ui carbonio-files-db carbonio-tasks-ce carbonio-tasks-db carbonio-tasks-ui carbonio-storages-ce carbonio-preview-ce carbonio-docs-connector-ce carbonio-docs-editor carbonio-prometheus carbonio-message-broker  carbonio-ws-collaboration-ce carbonio-ws-collaboration-db carbonio-ws-collaboration-ui carbonio-catalog carbonio-memcached"
+PACKAGES="postgresql-16 service-discover-server carbonio-directory-server carbonio-proxy carbonio-files-ui carbonio-mta carbonio-appserver carbonio-user-management carbonio-files-ce carbonio-files-public-folder-ui carbonio-files-db carbonio-tasks-ce carbonio-tasks-db carbonio-tasks-ui carbonio-storages-ce carbonio-preview-ce carbonio-docs-connector-ce carbonio-docs-editor carbonio-prometheus carbonio-message-broker  carbonio-ws-collaboration-ce carbonio-ws-collaboration-db carbonio-ws-collaboration-ui carbonio-catalog carbonio-memcached"
 
 echo '' > config.conf
 apt update -y -q

--- a/source/carbonio/architecture/components/component-proxy.rst
+++ b/source/carbonio/architecture/components/component-proxy.rst
@@ -28,7 +28,6 @@ The following packages are required for the **Proxy** component:
    carbonio-proxy
    carbonio-catalog
    carbonio-files-public-folder-ui
-   carbonio-webui
    carbonio-tasks-ui
    carbonio-files-ui
    carbonio-ws-collaboration-ui


### PR DESCRIPTION
## Why
`carbonio-webui` no longer exists as an installable package — removed and consolidated into `carbonio-core` (zextras/carbonio-core#177). Install docs/scripts still list it, which would send users onto a broken `apt`/`dnf install`.

Jira: https://zextras.atlassian.net/browse/CO-4207

## What
Drop `carbonio-webui` from all install commands / package lists / scripts:
- `source/_includes/_installation/step-package-install.rst`
- `source/_includes/_installation/step-package-install-single-cb.rst`
- `source/_includes/_architecture/_packages/component-proxy.rst`
- `source/_includes/_architecture/_components/component-proxy-ce.rst`
- `source/carbonio/architecture/components/component-proxy.rst`
- `source/carbonio-ce/scripts/install_carbonio_ce_singleserver_rhel.sh`
- `source/carbonio-ce/scripts/install_carbonio_ce_singleserver_ubuntu.sh`

Note: `source/carbonio/architecture/components.rst` and `source/carbonio-ce/architecture/components.rst` still list `carbonio-webui` under the Proxy component card — left untouched pending confirmation on whether webui functionality still belongs in that description now that it's bundled into `carbonio-core`.

Related PRs (same removal, other repos):
- zextras/carbonio-install-ansible#184
- zextras/sps-carbonio-ce-ansible-setup#1
- zextras/qa-scripts#1